### PR TITLE
plainbo,checkbox: make config initialization lazy

### DIFF
--- a/checkbox-ng/checkbox_ng/commands/__init__.py
+++ b/checkbox-ng/checkbox_ng/commands/__init__.py
@@ -35,17 +35,17 @@ class CheckboxCommand(CommandBase):
 
     gettext_domain = "checkbox-ng"
 
-    def __init__(self, provider_loader, config):
+    def __init__(self, provider_loader, config_loader):
         """
         Initialize a command with the specified arguments.
 
         :param provider_loader:
             A callable returning a list of Provider1 objects
-        :param config:
-            A Config object
+        :param config_loader:
+            A callable returning a Config object
         """
         self._provider_loader = provider_loader
-        self._config = config
+        self._config_loader = config_loader
 
     @property
     def provider_loader(self):
@@ -56,8 +56,8 @@ class CheckboxCommand(CommandBase):
         return self._provider_loader
 
     @property
-    def config(self):
+    def config_loader(self):
         """
-        configuration object associated with this command
+        a callable returning a Config object
         """
-        return self._config
+        return self._config_loader

--- a/checkbox-ng/checkbox_ng/commands/cli.py
+++ b/checkbox-ng/checkbox_ng/commands/cli.py
@@ -43,23 +43,23 @@ class CliCommand(PlainBoxCommand, CheckBoxCommandMixIn):
     """
     gettext_domain = "checkbox-ng"
 
-    def __init__(self, provider_loader, config, settings):
+    def __init__(self, provider_loader, config_loader, settings):
         self.provider_loader = provider_loader
-        self.config = config
+        self.config_loader = config_loader
         self.settings = settings
 
     def invoked(self, ns):
         # Run check-config, if requested
         if ns.check_config:
-            retval = CheckConfigInvocation(self.config).run()
+            retval = CheckConfigInvocation(self.config_loader).run()
             return retval
         if ns.new_ui:
             from checkbox_ng.commands.newcli import CliInvocation2
-            return CliInvocation2(self.provider_loader, self.config, ns,
+            return CliInvocation2(self.provider_loader, self.loader_config, ns,
                                   self.settings).run()
         else:
             from checkbox_ng.commands.oldcli import CliInvocation
-            return CliInvocation(self.provider_loader, self.config,
+            return CliInvocation(self.provider_loader, self.loader_config,
                                  self.settings, ns).run()
 
     def register_parser(self, subparsers):

--- a/checkbox-ng/checkbox_ng/commands/launcher.py
+++ b/checkbox-ng/checkbox_ng/commands/launcher.py
@@ -47,6 +47,7 @@ class LauncherCommand(CheckboxCommand):
     """
 
     def invoked(self, ns):
+        self.config = self.config_loader()
         try:
             with open(ns.launcher, 'rt', encoding='UTF-8') as stream:
                 first_line = stream.readline()

--- a/checkbox-ng/checkbox_ng/commands/service.py
+++ b/checkbox-ng/checkbox_ng/commands/service.py
@@ -69,9 +69,9 @@ def connect_to_session_bus():
 
 class ServiceInvocation:
 
-    def __init__(self, provider_loader, config, ns):
+    def __init__(self, provider_loader, config_loader, ns):
         self.provider_loader = provider_loader
-        self.config = config
+        self.config_loader = config_loader
         self.ns = ns
 
     def run(self):
@@ -79,7 +79,7 @@ class ServiceInvocation:
         logger.info(_("Setting up DBus objects..."))
         session_list = []  # TODO: load sessions
         logger.debug(_("Constructing Service object"))
-        service_obj = Service(self.provider_loader(), session_list, self.config)
+        service_obj = Service(self.provider_loader(), session_list, self.config_loader())
         logger.debug(_("Constructing ServiceWrapper"))
         service_wrp = ServiceWrapper(service_obj, on_exit=lambda: loop.quit())
         logger.info(_("Publishing all objects on DBus"))
@@ -116,7 +116,7 @@ class ServiceCommand(CheckboxCommand):
     """
 
     def invoked(self, ns):
-        return ServiceInvocation(self.provider_loader, self.config, ns).run()
+        return ServiceInvocation(self.provider_loader, self.config_loader, ns).run()
 
     def register_parser(self, subparsers):
         parser = subparsers.add_parser("service", help=_("spawn dbus service"))

--- a/checkbox-ng/checkbox_ng/commands/submit.py
+++ b/checkbox-ng/checkbox_ng/commands/submit.py
@@ -87,8 +87,8 @@ class SubmitCommand(PlainBoxCommand):
 
     gettext_domain = "checkbox-ng"
 
-    def __init__(self, config):
-        self.config = config
+    def __init__(self, config_loader):
+        self.config = config_loader()
 
     def invoked(self, ns):
         return SubmitInvocation(ns).run()

--- a/checkbox-ng/checkbox_ng/tools.py
+++ b/checkbox-ng/checkbox_ng/tools.py
@@ -45,23 +45,12 @@ class CheckboxToolBase(ToolBase):
     and version handling.
     """
 
-    def __init__(self):
-        """
-        Initialize all the variables, real stuff happens in main()
-        """
-        super().__init__()
-        self._config = self.get_config_cls().get()
+    def _load_config(self):
+        return self.get_config_cls().get()
 
     def _load_providers(self):
         all_providers.load()
         return all_providers.get_all_plugin_objects()
-
-    @property
-    def config(self):
-        """
-        A Config instance
-        """
-        return self._config
 
     @classmethod
     def get_exec_version(cls):
@@ -111,19 +100,19 @@ class CheckboxTool(CheckboxToolBase):
         from checkbox_ng.commands.submit import SubmitCommand
         from plainbox.impl.commands.cmd_check_config import CheckConfigCommand
         SRUCommand(
-            self._load_providers, self.config
+            self._load_providers, self._load_config
         ).register_parser(subparsers)
         CheckConfigCommand(
-            self.config
+            self._load_config
         ).register_parser(subparsers)
         ServiceCommand(
-            self._load_providers, self.config
+            self._load_providers, self._load_config
         ).register_parser(subparsers)
         SubmitCommand(
-            self.config
+            self._load_config
         ).register_parser(subparsers)
         LauncherCommand(
-            self._load_providers, self.config
+            self._load_providers, self._load_config
         ).register_parser(subparsers)
         SelfTestCommand(load_unit_tests).register_parser(subparsers)
 
@@ -143,7 +132,7 @@ class CheckboxServiceTool(SingleCommandToolMixIn, CheckboxToolBase):
 
     def get_command(self):
         from checkbox_ng.commands.service import ServiceCommand
-        return ServiceCommand(self._load_providers, self.config)
+        return ServiceCommand(self._load_providers, self._load_config)
 
 
 class CheckboxSubmitTool(SingleCommandToolMixIn, CheckboxToolBase):
@@ -160,7 +149,7 @@ class CheckboxSubmitTool(SingleCommandToolMixIn, CheckboxToolBase):
 
     def get_command(self):
         from checkbox_ng.commands.submit import SubmitCommand
-        return SubmitCommand(self.config)
+        return SubmitCommand(self._load_config)
 
 
 class CheckboxLauncherTool(SingleCommandToolMixIn, CheckboxToolBase):
@@ -177,4 +166,4 @@ class CheckboxLauncherTool(SingleCommandToolMixIn, CheckboxToolBase):
 
     def get_command(self):
         from checkbox_ng.commands.launcher import LauncherCommand
-        return LauncherCommand(self._load_providers, self.config)
+        return LauncherCommand(self._load_providers, self._load_config)

--- a/plainbox/plainbox/impl/box.py
+++ b/plainbox/plainbox/impl/box.py
@@ -82,13 +82,13 @@ class PlainBoxTool(PlainBoxToolBase):
         top-level subcommands.
         """
         # TODO: switch to plainbox plugins
-        RunCommand(self._load_providers, self._config).register_parser(
+        RunCommand(self._load_providers, self._load_config).register_parser(
             subparsers)
         SessionCommand(self._load_providers).register_parser(subparsers)
         DeviceCommand().register_parser(subparsers)
         PlainboxSelfTestCommand().register_parser(subparsers)
-        CheckConfigCommand(self._config).register_parser(subparsers)
-        DevCommand(self._load_providers, self._config).register_parser(
+        CheckConfigCommand(self._load_config).register_parser(subparsers)
+        DevCommand(self._load_providers, self._load_config).register_parser(
             subparsers)
         StartProviderCommand().register_parser(subparsers)
 

--- a/plainbox/plainbox/impl/commands/__init__.py
+++ b/plainbox/plainbox/impl/commands/__init__.py
@@ -68,13 +68,6 @@ class PlainBoxToolBase(ToolBase):
     known yet.
     """
 
-    def __init__(self):
-        """
-        Initialize all the variables, real stuff happens in main()
-        """
-        super().__init__()
-        self._config = None  # set in late_init()
-
     @classmethod
     @abc.abstractmethod
     def get_config_cls(cls):
@@ -85,16 +78,8 @@ class PlainBoxToolBase(ToolBase):
         that is suitable for the particular application.
         """
 
-    def late_init(self, early_ns):
-        """
-        Overridden version of late_init().
-
-        This method loads the configuration object and the list of providers
-        and stores them as instance attributes.
-        """
-        super().late_init(early_ns)
-        # Load plainbox configuration
-        self._config = self.get_config_cls().get()
+    def _load_config(self):
+        return self.get_config_cls().get()
 
     def _load_providers(self):
         logger.info("Loading all providers...")

--- a/plainbox/plainbox/impl/commands/cmd_analyze.py
+++ b/plainbox/plainbox/impl/commands/cmd_analyze.py
@@ -40,13 +40,14 @@ class AnalyzeCommand(PlainBoxCommand, CheckBoxCommandMixIn):
     Implementation of ``$ plainbox dev analyze``
     """
 
-    def __init__(self, provider_loader, config):
+    def __init__(self, provider_loader, config_loader):
         self.provider_loader = provider_loader
-        self.config = config
+        self.config_loader = config_loader
 
     def invoked(self, ns):
         from plainbox.impl.commands.inv_analyze import AnalyzeInvocation
-        return AnalyzeInvocation(self.provider_loader, self.config, ns).run()
+        return AnalyzeInvocation(
+            self.provider_loader, self.config_loader, ns).run()
 
     def register_parser(self, subparsers):
         parser = subparsers.add_parser(

--- a/plainbox/plainbox/impl/commands/cmd_run.py
+++ b/plainbox/plainbox/impl/commands/cmd_run.py
@@ -35,14 +35,15 @@ from plainbox.impl.transport import get_all_transports
 
 class RunCommand(PlainBoxCommand, CheckBoxCommandMixIn):
 
-    def __init__(self, provider_loader, config):
+    def __init__(self, provider_loader, config_loader):
         self.provider_loader = provider_loader
-        self.config = config
+        self.config_loader = config_loader
 
     def invoked(self, ns):
         from plainbox.impl.commands.inv_run import RunInvocation
-        return RunInvocation(self.provider_loader, self.config, ns,
-                             ns.use_colors).run()
+        return RunInvocation(
+            self.provider_loader, self.config_loader, ns, ns.use_colors
+        ).run()
 
     def register_parser(self, subparsers):
         parser = subparsers.add_parser(

--- a/plainbox/plainbox/impl/commands/cmd_script.py
+++ b/plainbox/plainbox/impl/commands/cmd_script.py
@@ -34,14 +34,14 @@ class ScriptCommand(PlainBoxCommand):
     unconditionally.
     """
 
-    def __init__(self, provider_loader, config):
+    def __init__(self, provider_loader, config_loader):
         self.provider_loader = provider_loader
-        self.config = config
+        self.config_loader = config_loader
 
     def invoked(self, ns):
         from plainbox.impl.commands.inv_script import ScriptInvocation
         return ScriptInvocation(
-            self.provider_loader, self.config, ns.job_id
+            self.provider_loader, self.config_loader, ns.job_id
         ).run()
 
     def register_parser(self, subparsers):

--- a/plainbox/plainbox/impl/commands/cmd_special.py
+++ b/plainbox/plainbox/impl/commands/cmd_special.py
@@ -29,13 +29,13 @@ class SpecialCommand(PlainBoxCommand, CheckBoxCommandMixIn):
     Implementation of ``$ plainbox special``
     """
 
-    def __init__(self, provider_loader, config):
+    def __init__(self, provider_loader, config_loader):
         self.provider_loader = provider_loader
-        self.config = config
+        self.config_loader = config_loader
 
     def invoked(self, ns):
         from plainbox.impl.commands.inv_special import SpecialInvocation
-        return SpecialInvocation(self.provider_loader, self.config, ns).run()
+        return SpecialInvocation(self.provider_loader, self.config_loader, ns).run()
 
     def register_parser(self, subparsers):
         parser = subparsers.add_parser(

--- a/plainbox/plainbox/impl/commands/dev.py
+++ b/plainbox/plainbox/impl/commands/dev.py
@@ -45,9 +45,9 @@ class DevCommand(PlainBoxCommand):
     Command hub for various development commands.
     """
 
-    def __init__(self, provider_loader, config):
+    def __init__(self, provider_loader, config_loader):
         self.provider_loader = provider_loader
-        self.config = config
+        self.config_loader = config_loader
 
     def invoked(self, ns):
         raise NotImplementedError()
@@ -58,9 +58,12 @@ class DevCommand(PlainBoxCommand):
             prog="plainbox dev",
             usage=_("plainbox dev <subcommand> ..."))
         subdev = parser.add_subparsers()
-        ScriptCommand(self.provider_loader, self.config).register_parser(subdev)
-        SpecialCommand(self.provider_loader, self.config).register_parser(subdev)
-        AnalyzeCommand(self.provider_loader, self.config).register_parser(subdev)
+        ScriptCommand(self.provider_loader,
+                      self.config_loader).register_parser(subdev)
+        SpecialCommand(self.provider_loader,
+                       self.config_loader).register_parser(subdev)
+        AnalyzeCommand(self.provider_loader,
+                       self.config_loader).register_parser(subdev)
         ParseCommand().register_parser(subdev)
         CrashCommand().register_parser(subdev)
         LogTestCommand().register_parser(subdev)

--- a/plainbox/plainbox/impl/commands/inv_analyze.py
+++ b/plainbox/plainbox/impl/commands/inv_analyze.py
@@ -44,8 +44,8 @@ logger = getLogger("plainbox.commands.analyze")
 
 class AnalyzeInvocation(CheckBoxInvocationMixIn):
 
-    def __init__(self, provider_loader, config, ns):
-        super().__init__(provider_loader, config)
+    def __init__(self, provider_loader, config_loader, ns):
+        super().__init__(provider_loader, config_loader)
         self.ns = ns
         self.unit_list = list(
             itertools.chain(*[

--- a/plainbox/plainbox/impl/commands/inv_check_config.py
+++ b/plainbox/plainbox/impl/commands/inv_check_config.py
@@ -30,10 +30,11 @@ class CheckConfigInvocation:
     time.
     """
 
-    def __init__(self, config):
-        self.config = config
+    def __init__(self, config_loader):
+        self.config_loader = config_loader
 
     def run(self):
+        self.config = self.config_loader()
         print(_("Configuration files:"))
         for filename in self.config.Meta.filename_list:
             if filename in self.config.filename_list:

--- a/plainbox/plainbox/impl/commands/inv_checkbox.py
+++ b/plainbox/plainbox/impl/commands/inv_checkbox.py
@@ -41,16 +41,23 @@ logger = getLogger("plainbox.commands.checkbox")
 
 class CheckBoxInvocationMixIn:
 
-    def __init__(self, provider_loader, config):
+    def __init__(self, provider_loader, config_loader):
         self.provider_loader = provider_loader
+        self.config_loader = config_loader
         self._provider_list = None
-        self.config = config
+        self._config = None
 
     @property
     def provider_list(self):
         if self._provider_list is None:
             self._provider_list = self.provider_loader()
         return self._provider_list
+
+    @property
+    def config(self):
+        if self._config is None:
+            self._config = self.config_loader()
+        return self._config
 
     def get_job_list(self, ns):
         """

--- a/plainbox/plainbox/impl/commands/inv_run.py
+++ b/plainbox/plainbox/impl/commands/inv_run.py
@@ -303,8 +303,8 @@ class RunInvocation(CheckBoxInvocationMixIn):
         time the loop-over-all-jobs is started.
     """
 
-    def __init__(self, provider_loader, config, ns, use_colors=True):
-        super().__init__(provider_loader, config)
+    def __init__(self, provider_loader, config_loader, ns, use_colors=True):
+        super().__init__(provider_loader, config_loader)
         self.ns = ns
         self._manager = None
         self._runner = None

--- a/plainbox/plainbox/impl/commands/inv_script.py
+++ b/plainbox/plainbox/impl/commands/inv_script.py
@@ -47,8 +47,8 @@ class ScriptInvocation(CheckBoxInvocationMixIn):
     the command is to be invoked.
     """
 
-    def __init__(self, provider_loader, config, job_id):
-        super().__init__(provider_loader, config)
+    def __init__(self, provider_loader, config_loader, job_id):
+        super().__init__(provider_loader, config_loader)
         self.job_id = job_id
 
     def run(self):

--- a/plainbox/plainbox/impl/commands/inv_special.py
+++ b/plainbox/plainbox/impl/commands/inv_special.py
@@ -30,8 +30,8 @@ logger = getLogger("plainbox.commands.special")
 
 class SpecialInvocation(CheckBoxInvocationMixIn):
 
-    def __init__(self, provider_loader, config, ns):
-        super().__init__(provider_loader, config)
+    def __init__(self, provider_loader, config_loader, ns):
+        super().__init__(provider_loader, config_loader)
         self.ns = ns
 
     def run(self):

--- a/plainbox/plainbox/impl/commands/test_dev.py
+++ b/plainbox/plainbox/impl/commands/test_dev.py
@@ -36,16 +36,16 @@ class TestDevCommand(TestCase):
         self.parser = argparse.ArgumentParser(prog='test')
         self.subparsers = self.parser.add_subparsers()
         self.provider_loader = lambda: [mock.Mock()]
-        self.config = mock.Mock()
+        self.config_loader = lambda: mock.Mock()
         self.ns = mock.Mock()
 
     def test_init(self):
-        dev_cmd = DevCommand(self.provider_loader, self.config)
+        dev_cmd = DevCommand(self.provider_loader, self.config_loader)
         self.assertIs(dev_cmd.provider_loader, self.provider_loader)
-        self.assertIs(dev_cmd.config, self.config)
+        self.assertIs(dev_cmd.config_loader, self.config_loader)
 
     def test_register_parser(self):
-        DevCommand(self.provider_loader, self.config).register_parser(
+        DevCommand(self.provider_loader, self.config_loader).register_parser(
             self.subparsers)
         with TestIO() as io:
             self.parser.print_help()

--- a/plainbox/plainbox/impl/commands/test_script.py
+++ b/plainbox/plainbox/impl/commands/test_script.py
@@ -40,18 +40,19 @@ class TestScriptCommand(TestCase):
     def setUp(self):
         self.parser = argparse.ArgumentParser(prog='test')
         self.subparsers = self.parser.add_subparsers()
-        self.provider_loader = lambda:[mock.Mock()]
-        self.config = mock.Mock()
+        self.provider_loader = lambda: [mock.Mock()]
+        self.config_loader = lambda: mock.Mock()
         self.ns = mock.Mock()
 
     def test_init(self):
-        script_cmd = ScriptCommand(self.provider_loader, self.config)
+        script_cmd = ScriptCommand(self.provider_loader, self.config_loader)
         self.assertIs(script_cmd.provider_loader, self.provider_loader)
-        self.assertIs(script_cmd.config, self.config)
+        self.assertIs(script_cmd.config_loader, self.config_loader)
 
     def test_register_parser(self):
-        ScriptCommand(self.provider_loader, self.config).register_parser(
-            self.subparsers)
+        ScriptCommand(
+            self.provider_loader, self.config_loader
+        ).register_parser(self.subparsers)
         with TestIO() as io:
             self.parser.print_help()
         self.assertIn("script    run a command from a job", io.stdout)
@@ -74,13 +75,15 @@ class TestScriptCommand(TestCase):
     @mock.patch("plainbox.impl.commands.inv_script.ScriptInvocation")
     def test_invoked(self, patched_ScriptInvocation):
         retval = ScriptCommand(
-            self.provider_loader, self.config).invoked(self.ns)
+            self.provider_loader, self.config_loader
+        ).invoked(self.ns)
         patched_ScriptInvocation.assert_called_once_with(
-            self.provider_loader, self.config, self.ns.job_id)
+            self.provider_loader, self.config_loader, self.ns.job_id)
         self.assertEqual(
             retval, patched_ScriptInvocation(
-                self.provider_loader, self.config,
-                self.ns.job_id).run.return_value)
+                self.provider_loader, self.config_loader,
+                self.ns.job_id
+            ).run.return_value)
 
 
 class ScriptInvocationTests(TestCase):
@@ -89,7 +92,7 @@ class ScriptInvocationTests(TestCase):
 
     def setUp(self):
         self.provider_loader = mock.Mock()
-        self.config = PlainBoxConfig()
+        self.config_loader = lambda: PlainBoxConfig()
         self.job_id = mock.Mock()
 
     def assertCommandOutput(self, actual, expected):
@@ -97,14 +100,15 @@ class ScriptInvocationTests(TestCase):
 
     def test_init(self):
         script_inv = ScriptInvocation(
-            self.provider_loader, self.config, self.job_id)
+            self.provider_loader, self.config_loader, self.job_id)
         self.assertIs(script_inv.provider_loader, self.provider_loader)
-        self.assertIs(script_inv.config, self.config)
+        self.assertIs(script_inv.config_loader, self.config_loader)
         self.assertIs(script_inv.job_id, self.job_id)
 
     def test_run_no_such_job(self):
         provider_loader = lambda: [DummyProvider1()]
-        script_inv = ScriptInvocation(provider_loader, self.config, self.JOB_ID)
+        script_inv = ScriptInvocation(
+            provider_loader, self.config_loader, self.JOB_ID)
         with TestIO() as io:
             retval = script_inv.run()
         self.assertCommandOutput(
@@ -117,7 +121,8 @@ class ScriptInvocationTests(TestCase):
 
     def test_run_job_without_command(self):
         provider_loader = lambda: [DummyProvider1([make_job(self.JOB_PARTIAL_ID)])]
-        script_inv = ScriptInvocation(provider_loader, self.config, self.JOB_ID)
+        script_inv = ScriptInvocation(
+            provider_loader, self.config_loader, self.JOB_ID)
         with TestIO() as io:
             retval = script_inv.run()
         self.assertCommandOutput(
@@ -131,7 +136,8 @@ class ScriptInvocationTests(TestCase):
     def test_job_with_command(self, mock_check_output):
         provider_loader = lambda: [DummyProvider1([
             make_job(self.JOB_PARTIAL_ID, command='echo ok')])]
-        script_inv = ScriptInvocation(provider_loader, self.config, self.JOB_ID)
+        script_inv = ScriptInvocation(
+            provider_loader, self.config_loader, self.JOB_ID)
         with TestIO() as io:
             retval = script_inv.run()
         self.assertCommandOutput(
@@ -147,7 +153,8 @@ class ScriptInvocationTests(TestCase):
     def test_job_with_command_making_files(self, mock_check_output):
         provider_loader = lambda: [DummyProvider1([
             make_job(self.JOB_PARTIAL_ID, command='echo ok > file')])]
-        script_inv = ScriptInvocation(provider_loader, self.config, self.JOB_ID)
+        script_inv = ScriptInvocation(
+            provider_loader, self.config_loader, self.JOB_ID)
         with TestIO() as io:
             retval = script_inv.run()
         self.maxDiff = None
@@ -165,7 +172,8 @@ class ScriptInvocationTests(TestCase):
     def test_job_with_command_making_directories(self, mock_check_output):
         provider_loader = lambda: [DummyProvider1([
             make_job(self.JOB_PARTIAL_ID, command='mkdir dir')])]
-        script_inv = ScriptInvocation(provider_loader, self.config, self.JOB_ID)
+        script_inv = ScriptInvocation(
+            provider_loader, self.config_loader, self.JOB_ID)
         with TestIO() as io:
             retval = script_inv.run()
         self.maxDiff = None


### PR DESCRIPTION
This patch changes the config variable, that used to be passed around
between all the commands and their implementation, to the config_loader
function. The function, similar to the existing provider_loader, returns
a config object when called.

The CheckBoxInvocationMixIn from plainbox.impl.commands.inv_checkbox
(which is overdue for a rename) also gained a config property that lazily
calls the config_loader. This makes many command line tools oblivious
to this change as they can still access `self.config` in the same way.

The PlainBoxToolBase class lost it's init and late_init method, since they
no longer did anything useful. In exchange it gained the _load_config()
method which simply uses get_config_cls() to load and initialize the
configuration object. It is the same method that is passed to the
initializer of many command classes now.

Similar changes affected checkbox-ng's equivalent, the CheckBoxToolBase
class.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
